### PR TITLE
Remove cast to int for item weight

### DIFF
--- a/Model/EasyshipCarrier.php
+++ b/Model/EasyshipCarrier.php
@@ -249,7 +249,7 @@ class EasyshipCarrier extends AbstractCarrier implements CarrierInterface
     protected function getWeight($item)
     {
         if ($item->hasWeight() && !empty($item->getWeight())) {
-            return (int)$item->getWeight();
+            return $item->getWeight();
         }
 
         return 1;


### PR DESCRIPTION
Remove cast to int for item weight. This allows rates to be shown for products under 0.5Kg and more accurate rates for all other products.