### PR TITLE
[Fix] order-inventory-set-source-code-default

### DIFF
--- a/Model/ShipOrder.php
+++ b/Model/ShipOrder.php
@@ -93,6 +93,7 @@ class ShipOrder implements \Goeasyship\Shipping\Api\ShipOrderInterface
         }
 
         $shipment->setShipmentStatus(\Magento\Sales\Model\Order\Shipment::STATUS_NEW);
+        $shipment->getExtensionAttributes()->setSourceCode('default');
 
         $shipment->register();
 
@@ -107,7 +108,7 @@ class ShipOrder implements \Goeasyship\Shipping\Api\ShipOrderInterface
         } catch (\Exception $e) {
             $connection->rollBack();
             throw new \Magento\Framework\Exception\CouldNotSaveException(
-                __('Could not save a shipment, see error log for details')
+                __('Could not save a shipment, see error log for details' . $e->getMessage())
             );
         }
 


### PR DESCRIPTION
#### Description
- Currently for stores activated MSI(Multi Source Inventory) feature, it's not possible to update the fulfillment status on Magento2 successfully. It's due to the ExtensionAttributes not being set before saving shipment.
- add setSourceCode to default process
- add detailed error

* Pending:
  * fully support MSI

#### Related Issue
- #18 