### PR TITLE
[Fix] rate-at-checkout-item-currency-mismatch: modify currency settings

### DIFF
--- a/Model/EasyshipCarrier.php
+++ b/Model/EasyshipCarrier.php
@@ -159,8 +159,6 @@ class EasyshipCarrier extends AbstractCarrier implements CarrierInterface
     {
         $this->_request = $request;
 
-        $currencyCode = $this->_storeManager->getStore()->getCurrentCurrencyCode();
-
         $r = new \Magento\Framework\DataObject();
 
         if ($request->getOrigCountry()) {
@@ -198,6 +196,7 @@ class EasyshipCarrier extends AbstractCarrier implements CarrierInterface
         }
 
         $this->setAddressToRequest($r, $request);
+        $r->setData('output_currency', $this->_storeManager->getStore()->getCurrentCurrencyCode());
 
         $items = [];
         if ($request->getAllItems()) {
@@ -214,7 +213,7 @@ class EasyshipCarrier extends AbstractCarrier implements CarrierInterface
                         'width' => $this->getEasyshipWidth($item->getProduct()),
                         'length' => $this->getEasyshipLength($item->getProduct()),
                         'category' => $this->getEasyshipCategory($item->getProduct()),
-                        'declared_currency' => $currencyCode,
+                        'declared_currency' => $this->_storeManager->getStore()->getBaseCurrencyCode(),
                         'declared_customs_value' => (float)$item->getPrice(),
                         'sku' => $item->getSku()
                     ];

--- a/Model/EasyshipCarrier.php
+++ b/Model/EasyshipCarrier.php
@@ -374,13 +374,14 @@ class EasyshipCarrier extends AbstractCarrier implements CarrierInterface
 
         $result = $this->_rateResultFactory->create();
         foreach ($prefer_rates as $rate) {
+            $convertedPrice = $currentCurrency->convert($rate['total_charge'], $baseCurrencyCode);
             $method = $this->_rateMethodFactory->create();
             $method->setCarrier($this->_code);
             $method->setCarrierTitle($rate['courier_name']);
             $method->setMethod($rate['short_courier_id']);
             $method->setMethodTitle($rate['full_description']);
-            $method->setCost($currentCurrency->convert($rate['total_charge'], $baseCurrencyCode));
-            $method->setPrice($currentCurrency->convert($rate['total_charge'], $baseCurrencyCode));
+            $method->setCost($convertedPrice);
+            $method->setPrice($convertedPrice);
             $result->append($method);
         }
 

--- a/Model/EasyshipCarrier.php
+++ b/Model/EasyshipCarrier.php
@@ -369,12 +369,13 @@ class EasyshipCarrier extends AbstractCarrier implements CarrierInterface
          * @var \Magento\Shipping\Model\Rate\Result $result
          * @var \Magento\Quote\Model\Quote\Address\RateResult\Method $method
          */
-        $currentCurrency = $this->_storeManager->getStore()->getCurrentCurrency();
-        $baseCurrencyCode = $this->_storeManager->getStore()->getBaseCurrencyCode();
+        $currentCurrencyCode = $this->_storeManager->getStore()->getCurrentCurrencyCode();
+        $baseCurrency = $this->_storeManager->getStore()->getBaseCurrency();
+        $convertRate = $baseCurrency->getRate($currentCurrencyCode);
 
         $result = $this->_rateResultFactory->create();
         foreach ($prefer_rates as $rate) {
-            $convertedPrice = $currentCurrency->convert($rate['total_charge'], $baseCurrencyCode);
+            $convertedPrice = $rate['total_charge'] / $convertRate;
             $method = $this->_rateMethodFactory->create();
             $method->setCarrier($this->_code);
             $method->setCarrierTitle($rate['courier_name']);


### PR DESCRIPTION
#### Description
- Current Issues:
  1. Not specifying the output currency sending to Easyship for processing and causing the mismatch of the displayed value.
  2. the declared_custom_value is not including tax and discount.
  3. The returned rates will be in displayed currency but Magento will accept base currency and convert it.
- Solution:
  1. add output currency code to the request
  2. add an equation to calculate the price with discount and tax when sending requests to Easyship
  3. add an equation to process
- Deployed to Magento2 CE and tested

#### Links
- [Magento2 Source code](https://github.com/magento/magento2)
- [Ref Documentation](https://www.magentoextensions.org/documentation/)

#### Asana Story
- https://app.asana.com/0/1202904056634036/1201492498950857/f